### PR TITLE
Update cluster configuration in form.yml.erb

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,6 +1,8 @@
 ---
 title: "Protein Prediction"
-cluster: "rc"
+cluster:
+  - rc
+  - 2e
 
 form:
   - session_type


### PR DESCRIPTION
Add second "2e" cluster as a workaround for OOD 4.1 support due to mismatched names on RoarCollab